### PR TITLE
Fixes typo in Dock Widget

### DIFF
--- a/breeder_map_dockwidget_base.ui
+++ b/breeder_map_dockwidget_base.ui
@@ -132,7 +132,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="lbColGap">
         <property name="text">
-         <string>Coumn Gap</string>
+         <string>Column Gap</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Fixed typo "Coumn Gap" to "Column Gap"

Fixes issue #6 