### PR TITLE
Changed setWidth arguments for 2 map gui elements

### DIFF
--- a/breeder_map_dockwidget.py
+++ b/breeder_map_dockwidget.py
@@ -533,12 +533,12 @@ class MapTool(QgsMapTool):
         # cutting lines
         self.rbLines = QgsRubberBand(self.canvas, QgsWkbTypes.LineGeometry)
         self.rbLines.setColor(QColor(40, 180, 30, 255))
-        self.rbLines.setWidth(1.5)
+        self.rbLines.setWidth(2)
 
         # plots
         self.rbPlots = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
         self.rbPlots.setStrokeColor(QColor(200, 120, 70, 150))
-        self.rbPlots.setWidth(0.8)
+        self.rbPlots.setWidth(1)
 
         self.rubbers = [
             self.rb,


### PR DESCRIPTION
Changed line setWidth arguments as method requires int. QgsRubberBand.setWidth() requires an int causing plugin not to load. Tested on linux in QGIS 3.24 & Python 3.10.5. Works on Windows QGIS 3.22.2 on python 3.10.4 prior to change however.

Stack trace when crashing.
Traceback (most recent call last):
File "breeder_map.py", line 299, in run
self.dockwidget = BreederMapDockWidget(self)
File "breeder_map_dockwidget.py", line 85, in init
self.mt = MapTool(self)
File "breeder_map_dockwidget.py", line 536, in init
self.rbLines.setWidth(1.5)
TypeError: QgsRubberBand.setWidth(): argument 1 has unexpected type 'float'

*removed file location
